### PR TITLE
Centered contacts (closes #42)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blasting Ryu</title>
     <link rel="stylesheet" href="https://volodymyrkushnir.com/assets/stylesheets/base.css" />
     <link rel="stylesheet" href="./styles/main.css" />
@@ -34,25 +35,25 @@
                     <div class="job">Professional street fighter</div>
                     <ul class="contacts">
                       <li>
-                        <a href="https://bit.ly/3bZLGBl" rel="author" class="facebook icon-text">
+                        <a href="https://bit.ly/3bZLGBl" rel="author" class="facebook">
                           <i class="fab fa-facebook-square fa-lg"></i>
                           <span>Ryu Hoshi</span>
                         </a>
                       </li>
                       <li>
-                        <a href="mailto:ryuwins@gmail.com" rel="author" class="mail icon-text">
+                        <a href="mailto:ryuwins@gmail.com" rel="author" class="mail">
                           <i class="fas fa-envelope fa-lg"></i>
                           <span>ryuwins@gmail.com</span>
                         </a>
                       </li>
                       <li>
-                        <a href="https://bit.ly/3d8ZEBa" rel="author" class="twitter icon-text">
+                        <a href="https://bit.ly/3d8ZEBa" rel="author" class="twitter">
                           <i class="fab fa-twitter-square fa-lg"></i>
                           <span>denjinryu</span>
                         </a>
                       </li>
                       <li>
-                        <a href="https://bit.ly/3fkB8z5" rel="author" class="instagram icon-text">
+                        <a href="https://bit.ly/3fkB8z5" rel="author" class="instagram">
                           <i class="fab fa-instagram-square fa-lg"></i>
                           <span>sworn_ryu</span>
                         </a>


### PR DESCRIPTION
Removed own class icon-text, because framework automatically centers only block elements.